### PR TITLE
fix: fix license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "ld2410-ble"
 version = "0.2.0"
 description = "Interface with LD2410B modules from HiLink"
 authors = ["930913 <3722064+930913@users.noreply.github.com>"]
-license = "Apache Software License 2.0"
 readme = "README.md"
 repository = "https://github.com/930913/ld2410-ble"
 documentation = "https://ld2410-ble.readthedocs.io"
@@ -13,6 +12,7 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
+    "License :: OSI Approved :: Apache Software License",
 ]
 packages = [
     { include = "ld2410_ble", from = "src" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "ld2410-ble"
 version = "0.2.0"
 description = "Interface with LD2410B modules from HiLink"
 authors = ["930913 <3722064+930913@users.noreply.github.com>"]
+license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/930913/ld2410-ble"
 documentation = "https://ld2410-ble.readthedocs.io"
@@ -12,7 +13,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
-    "License :: OSI Approved :: Apache Software License",
 ]
 packages = [
     { include = "ld2410_ble", from = "src" },


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing at Home Assistant, and I found that we could not detect the license of this library properly. According to pyproject.toml documentation about the `license` field:
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with License ::. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)

If you could do a release after this PR, and maybe bump in Home Assistant, that would be awesome :)