### PR TITLE
Retries bluetooth connection on BleakError

### DIFF
--- a/src/ld2410_ble/ld2410_ble.py
+++ b/src/ld2410_ble/ld2410_ble.py
@@ -331,8 +331,8 @@ class LD2410BLE:
             await self._ensure_connected()
             _LOGGER.debug("ensured connection - initialising")
             await self.initialise()
-        except BleakNotFoundError:
-            _LOGGER.debug("failed to ensure connection - backing off")
+        except (BleakNotFoundError, BleakError) as error:
+            _LOGGER.debug("failed to ensure connection - backing off: %s", error)
             await asyncio.sleep(BLEAK_BACKOFF_TIME)
             _LOGGER.debug("reconnecting again")
             asyncio.create_task(self._reconnect())


### PR DESCRIPTION
In home assistant the LD2410 device was constantly becoming unavailable (triggered perhaps by an issue with my BT proxies or the device itself).

While tracking this issue down I found that in certain instances the LD2410 goes away which triggers a reconnection in this library.  If the reconnection reaches an exception other than BleakNotFoundError this handler stops the retry attempts, which leaves the device as unavailable forever unless we reload the integration in home assistant. 

This PR adds this exception to the poll of retry attempts fixing the problem.